### PR TITLE
fix history bug

### DIFF
--- a/src/tree/store/index.ts
+++ b/src/tree/store/index.ts
@@ -10,7 +10,18 @@ import {commonSetting} from './commonSetting';
 import {nodeSize} from './nodeSize';
 
 const history = undoable(combineReducers({tree, commonSetting}), {
-  filter: excludeAction([INITIALIZE_ACTION_TYPE]),
+  // TODO: Originally, ADD_NODE_SIZE is not necessary.
+  // But without it, exclusion of INITIALIZE_ACTION_TYPE will not work.
+  // It may be a bug in the library.
+  // How to reproduce the bug
+  // 1. Replace [INITIALIZE_ACTION_TYPE, 'ADD_NODE_SIZE'] to [INITIALIZE_ACTION_TYPE]
+  // 2. Transition to top page
+  // 3. Reload
+  // 4. Transition to / tree
+  // 5. INITIALIZE_ACTION_TYPE is included in history
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  filter: excludeAction([INITIALIZE_ACTION_TYPE, 'ADD_NODE_SIZE']),
 });
 
 export const reducer = combineReducers({history, nodeSize, displayScale});


### PR DESCRIPTION
How to reproduce the bug

1. Replace [INITIALIZE_ACTION_TYPE, 'ADD_NODE_SIZE'] to [INITIALIZE_ACTION_TYPE]
2. Transition to top page
3. Reload
4. Transition to / tree
5. INITIALIZE_ACTION_TYPE is included in history